### PR TITLE
Add scrolling to preview pane and fix footer overflow

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -91,6 +91,8 @@ footer
   font-family Noticia Text, Georgia, serif
   left 50%
   border-left 1px solid #ddd
+  overflow scroll
+  padding-bottom 30px
   padding 65px 20px 45px
   h1, h2, h3, h4, h5, h6
     margin 0 0 0.5em


### PR DESCRIPTION
There's no scrolling in the div when the result is too big to be previewed.

Also, the bottom footer overflows the last few lines.

This might be an ugly way of doing this, but it kind of works for me.
